### PR TITLE
减小了CY2021一类比赛的高度 / 优化CSS

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -46,20 +46,18 @@
 
     <!-- 赛事列表 -->
     <ul class="competitions-list-row">
-        <li class="competition-item">
+        <li class="competition-item major-competition">
             <a href="https://cubing.com/competition/Nanchang-Winter-2015" 
-               target="_blank"
-               class="game">
+               target="_blank">
                 <img src="https://cdn.jsdelivr.net/gh/youranium/source-cdn/images/content/2015NCW.jpg"
                      alt="2015NCW"
                      class="competition-img">
                 2015年WCA南昌冬季魔方赛
             </a>
         </li>
-        <li class="competition-item">
+        <li class="competition-item minor-competition">
             <a href="#"
-               target="_blank"
-               class="Schoolgame">
+               target="_blank">
                 <img src="https://cdn.jsdelivr.net/gh/youranium/source-cdn/images/content/2021ChungYeung.png"
                      alt="2021CY"
                      class="competition-img">

--- a/css/base.css
+++ b/css/base.css
@@ -48,7 +48,7 @@ body {
     word-spacing: 0;
 }
 
-#menu-bar a:not(#page-active) {
+#menu-bar a:not(#page-active, #menu-bar a:hover) {
     color: rgb(82, 79, 79);
 }
 

--- a/css/competitions.css
+++ b/css/competitions.css
@@ -1,33 +1,60 @@
 /* 赛事页面 */
 
+/* 比赛行（一行三个比赛） */
 .competitions-list-row {
-    list-style: none;
-    padding-top: 30px;
-    text-decoration: none;
     position: relative;
+    height: 280px;
+    display: flex;
+    align-items: center;
+    list-style: none;
+    text-decoration: none;
 }
 
+/* 单个比赛 */
 .competition-item {
-    box-shadow: 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-    border-radius: 12px;
-    height: 240px;
+    position: absolute;
     width: 300px;
+    box-sizing: border-box;
+    padding: 7px;
     background-color: rgb(239,178,73);
+    border-radius: 12px;
+    box-shadow: 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     text-align: center;
     transition-timing-function: ease-out;
     transition-property: height, width, left, right, font-size;
     transition-duration: 1s;
-    position: absolute;
-    box-sizing: border-box;
-    padding: 7px;
 }
 
 .competition-item:hover {
-    font-size: 18px;
-    height: 260px;
     width: 320px;
+    font-size: 18px;
 }
 
+/* 比赛标题 */
+.competition-item a {
+    color: rgb(82, 79, 79);
+    text-decoration: none;
+}
+
+/* 主要的比赛，如 NCW2015 */
+.major-competition {
+    height: 240px;
+}
+
+.major-competition:hover {
+    height: 255px;
+}
+
+/* 次要的比赛，如 CY2021 */
+.minor-competition {
+    height: 210px;
+}
+
+.minor-competition:hover {
+    height: 225px;
+}
+
+/* 每行各个比赛的位置（左，中，右） */
 .competition-item:nth-child(1) {
     left: 10%;
 }
@@ -40,6 +67,7 @@
     right: 10%;
 }
 
+/* 针对每行各个比赛hover时的位置偏移微调 */
 .competition-item:nth-child(1):hover {
     left: calc(10% - 10px);
 }
@@ -49,14 +77,9 @@
 .competition-item:nth-child(3):hover {
     right: calc(10% - 10px);
 }
-
-.competition-item a {
-    text-decoration: none;
-    color: rgb(82, 79, 79);
-}
   
 .competition-img {
-    border-radius: 12px;
     height: auto;
     width: 100%;
+    border-radius: 12px;
 }


### PR DESCRIPTION
- 添加了比赛类型对高度的影响
  - `competitions.html` 中，每个 `<ul class="competitions-list-row">` 为一个比赛行，一行三个 `<li class="competition-item">` （即比赛）
  - 为 `<li>` 添加class `major-competition` 即为大型比赛（高度较高）
  - 为 `<li>` 添加class `minor-competition` 即为小型比赛（高度较低）
- 修复了鼠标移上菜单选项时字体不变白的问题

2021.9.10